### PR TITLE
Make features additive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ alloc = []
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["no-std", "algorithms", "data-structures", "rust-patterns"]
 [dependencies]
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,9 @@ categories = ["no-std", "algorithms", "data-structures", "rust-patterns"]
 [dependencies]
 
 [features]
-no_std = []
+default = ["std"]
+std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,22 @@
 #![doc = include_str!("../README.md")]
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use core::ptr::NonNull;
 use core::mem::MaybeUninit;
 use core::marker::PhantomData;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 mod mut_cursor_vec;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use mut_cursor_vec::*;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 mod rooted_vec;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use rooted_vec::*;
 
 /// Stores a stack of `&mut` references, only allowing access to the top element on the stack

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,16 @@ use core::ptr::NonNull;
 use core::mem::MaybeUninit;
 use core::marker::PhantomData;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod mut_cursor_vec;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use mut_cursor_vec::*;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod rooted_vec;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use rooted_vec::*;
 
 /// Stores a stack of `&mut` references, only allowing access to the top element on the stack

--- a/src/mut_cursor_vec.rs
+++ b/src/mut_cursor_vec.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 
 /// Similar to [MutCursor](crate::MutCursor), but allows for a dynamically growing stack
 ///
-/// `MutCursorVec` is not available if the `no_std` feature is set
+/// `MutCursorVec` is not available if the `alloc` feature is disabled. (The feature is enabled by default.)
 pub struct MutCursorVec<'root, T: ?Sized + 'root> {
     top: NonNull<T>,
     stack: alloc::vec::Vec<NonNull<T>>,

--- a/src/rooted_vec.rs
+++ b/src/rooted_vec.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 /// `MutCursorRootedVec` doesn't implement [Deref](core::ops::Deref), and accessors return [Option], so therefore it is
 /// allowed to be empty, unlike some of the other types in this crate.
 ///
-/// `MutCursorRootedVec` is not available if the `no_std` feature is set
+/// `MutCursorRootedVec` is not available if the `alloc` feature is disabled. (The feature is enabled by default.)
 pub struct MutCursorRootedVec<RootT, NodeT: ?Sized> {
     top: Option<NonNull<NodeT>>,
     root: Option<RootT>,


### PR DESCRIPTION
The `no_std` feature violates the principle that features must be additive. If one crated depended on `mutcursor` without requiring std, and thus sets the `no_std` feature; and another crate depends on `mutcursor` *with* the need for the `std`-enabled features, then downstream users depending on *both* those crates can't compile, because the feature `no_std` would result in being *enabled* from cargo’s unification of features in shared transitive dependencies.

The existing `no_std` feature is subtractive (enabling the feature *removes* API) but features must be additive instead (enabling the feature *adds* API). The common practice to solve this is to offer additive features called `alloc` or `std`, which are enabled by default (as a default feature) for convenience of the common not-`non_std` user.

This PR also adds some cfg for displaying the documentation more nicely on docs.rs.