### PR TITLE
Sound rooted interface idea

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ keywords = ["traversal", "tree", "backtacking", "stack", "cursor"]
 categories = ["no-std", "algorithms", "data-structures", "rust-patterns"]
 
 [dependencies]
+maybe-dangling = { version = "0.1.1", optional = true}
+stable_deref_trait = { version = "1.2.0", default-features = false, optional = true, features = ["alloc"] }
 
 [features]
-default = ["alloc"]
-alloc = []
+default = ["std"]
+alloc = ["dep:maybe-dangling", "dep:stable_deref_trait"]
+std = ["alloc", "stable_deref_trait/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ alloc = []
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["no-std", "algorithms", "data-structures", "rust-patterns"]
 [dependencies]
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,9 @@ categories = ["no-std", "algorithms", "data-structures", "rust-patterns"]
 [dependencies]
 
 [features]
-no_std = []
+default = ["std"]
+std = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ stable_deref_trait = { version = "1.2.0", default-features = false, optional = t
 
 [features]
 default = ["std"]
+# Enables the `MutCursorVec` and `MutCursorRootedVec` APIs.
 alloc = ["dep:maybe-dangling", "dep:stable_deref_trait"]
+# Enables `std` support for `StableDeref`, so you use std-only stable pointers
+# without needing to depend on `stable_deref_trait` yourself.
 std = ["alloc", "stable_deref_trait/std"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 This crate provides types to safely store mutable references to parent nodes, for backtracking during traversal of tree & graph structures.
 
-[MutCursor] is more efficient because it avoids dynamic allocation, while [MutCursorVec] provides for an arbitrarily deep stack.
+[`MutCursor`] is more efficient because it avoids dynamic allocation, while [`MutCursorVec`] provides for an arbitrarily deep stack.
 
-[MutCursorRootedVec] supports mutable references to a separate root type and a different leaf type.  In the future I may generalize this pattern to be more flexible.
+[`MutCursorRootedVec`] supports mutable references to a separate root type and a different leaf type.  In the future I may generalize this pattern to be more flexible.
 
 ## Usage
 ```rust
@@ -49,15 +49,15 @@ impl TreeNode {
 
 This crate basically does the same thing as [generic-cursors](https://crates.io/crates/generic-cursors). However, there are several reasons to choose this crate:
 
-1. The fixed-size stack used by [MutCursor] has lower overhead than a [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html), and can be used in a `no_std` environment where dynamic allocation may be unavailable.
+1. The fixed-size stack used by [`MutCursor`] has lower overhead than a [`Vec`], and can be used in a `no_std` environment where dynamic allocation may be unavailable.
 
-2. The [MutCursor::try_map_into_mut] API enables some paterns that would be otherwise impossible.
+2. The [`MutCursor::try_map_into_mut`] API enables some patterns that would be otherwise impossible.
 
 ## Safety Thesis
 
-Each `&mut` reference stored by a [MutCursor] mutably borrows the reference beneath it in the stack.  The stack root takes a mutable (and therefore exclusive) borrow of the node itself.  Therefore the stack's [top](MutCursor::top) is an exclusive borrow.
+Each `&mut` reference stored by a [`MutCursor`] mutably borrows the reference beneath it in the stack.  The stack root takes a mutable (and therefore exclusive) borrow of the node itself.  Therefore the stack's [`top`] is an exclusive borrow.
 
-You can imagine unrolling tree traversal into something like the code below, but this isn't amenable to looping.  In essence each `level` variable is preserved, but inaccessible because the level above is mutably borrowing it.  The [MutCursor] object contains all the `level` variables but only provides access to the [top](MutCursor::top)
+You can imagine unrolling tree traversal into something like the code below, but this isn't amenable to looping.  In essence each `level` variable is preserved, but inaccessible because the level above is mutably borrowing it.  The [`MutCursor`] object contains all the `level` variables but only provides access to the [`top`].
 
 ```rust ignore
 let level_1 = &mut root;
@@ -76,12 +76,19 @@ let level_1 = &mut root;
 
 #### Macro to define cursor types
 
-In the current design of [MutCursorRootedVec], there is a predefined pattern prescribing where `RootT` and `NodeT` types may exist on the stack.  However, we may find it necessary in the future to support more than two types, in a more flexible pattern.  It seems that a macro to define a bespoke cursor type is the best solutuion.
+In the current design of [`MutCursorRootedVec`], there is a predefined pattern prescribing where `RootT` and `NodeT` types may exist on the stack.  However, we may find it necessary in the future to support more than two types, in a more flexible pattern.  It seems that a macro to define a bespoke cursor type is the best solutuion.
 
 #### Internal enum for multiple-type support at runtime
 
-For ultimate flexibility, we would want all the references to be stored by the stack as in an enum over the possible reference types.  However, if ther user provided an enum as a type parameter to a cursor type, the result result would be double-indirection.  Therefore the enum behavior would need to be internal to the MutCursor.  Deriving a MutCursor from a user's enum type feels like a friendly way to define the types a cursor type is capable of storing.
+For ultimate flexibility, we would want all the references to be stored by the stack as in an enum over the possible reference types.  However, if the user provided an enum as a type parameter to a cursor type, the result result would be double-indirection.  Therefore the enum behavior would need to be internal to the MutCursor.  Deriving a MutCursor from a user's enum type feels like a friendly way to define the types a cursor type is capable of storing.
 
 ## Acknowledgements
 
 [Frank Steffahn](https://github.com/steffahn) identified soundness issues and potential improvements in prior versions of this crate.
+
+[`MutCursor`]: https://docs.rs/mutcursor/latest/mutcursor/struct.MutCursor.html
+[`top`]: https://docs.rs/mutcursor/latest/mutcursor/struct.MutCursor.html#method.top
+[`MutCursor::try_map_into_mut`]: https://docs.rs/mutcursor/latest/mutcursor/struct.MutCursor.html#method.try_map_into_mut
+[`MutCursorVec`]: https://docs.rs/mutcursor/latest/mutcursor/struct.MutCursorVec.html
+[`MutCursorRootedVec`]: https://docs.rs/mutcursor/latest/mutcursor/struct.MutCursorRootedVec.html
+[`Vec`]: https://doc.rust-lang.org/std/vec/struct.Vec.html

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This crate provides types to safely store mutable references to parent nodes, fo
 
 [MutCursor] is more efficient because it avoids dynamic allocation, while [MutCursorVec] provides for an arbitrarily deep stack.
 
-[MutCursorRootedVec] supports mutable references to a separate root type and a different leaf type.  In the future I may generalize this pattern to be more flexible.  **WARNING** `MutCursorRootedVec` is unsound when the root object owns the memory it references!
+[MutCursorRootedVec] supports mutable references to a separate root type and a different leaf type.  In the future I may generalize this pattern to be more flexible.
 
 ## Usage
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,55 @@
+// Overrides for `docs.rs` links in the README. This first definition takes precedence.
+
+// fix broken links if documented without `alloc`:
+#![cfg_attr(not(feature = "alloc"), doc = "[`MutCursorVec`]: features#alloc")]
+#![cfg_attr(not(feature = "alloc"), doc = "[`MutCursorRootedVec`]: features#alloc")]
+
+// more precise links to `std`/`alloc` when possible:
+#![cfg_attr(feature = "std", doc = "[Vec]: std::vec::Vec")]
+#![cfg_attr(feature = "alloc", doc = "[Vec]: alloc::vec::Vec")]
+
+// Normal link to crate items:
+//! [`MutCursor`]: MutCursor
+//! [`top`]: MutCursor::top
+//! [`MutCursor::try_map_into_mut`]: MutCursor::try_map_into_mut
+//! [`MutCursorVec`]: MutCursorVec
+//! [`MutCursorRootedVec`]: MutCursorRootedVec
+
 #![doc = include_str!("../README.md")]
 
-#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+#![no_std]
+
+#[cfg(any(test, feature = "alloc"))]
+extern crate alloc;
+#[cfg(any(test, feature = "std"))]
+#[cfg_attr(test, macro_use)]
+extern crate std;
+
+#[cfg(doc)]
+#[cfg_attr(docsrs, doc(cfg(doc)))]
+pub mod features {
+    //! Description of the crate features (not a real module).
+    //!
+    //! ## `default`
+    //! The default features of this crate include `std` and `alloc`
+    //! ## `alloc`
+    //! Enables usage of the `alloc` crate, and a public dependency on
+    //! [`stable_deref_trait`] at version `1.*`
+    //!
+    #![cfg_attr(not(feature = "alloc"), doc = "Enables the `MutCursorVec` and `MutCursorRootedVec` APIs.")]
+    #![cfg_attr(feature = "alloc", doc = "Enables the [`MutCursorVec`] and [`MutCursorRootedVec`] APIs.")]
+    //! ## `std`
+    //! Enables `std` support for [`StableDeref`], so you use std-only stable pointers
+    //! without needing to depend on [`stable_deref_trait`] yourself.
+    //!
+    #![cfg_attr(feature = "alloc", doc = "[`stable_deref_trait`]: stable_deref_trait")]
+    #![cfg_attr(feature = "alloc", doc = "[`StableDeref`]: stable_deref_trait::StableDeref")]
+    //! [`stable_deref_trait`]: https://docs.rs/stable_deref_trait/1/stable_deref_trait/
+    //! [`StableDeref`]: https://docs.rs/stable_deref_trait/1/stable_deref_trait/trait.StableDeref.html
+    use super::*;
+}
 
 use core::ptr::NonNull;
 use core::mem::MaybeUninit;
@@ -21,7 +69,7 @@ pub use rooted_vec::*;
 
 /// Stores a stack of `&mut` references, only allowing access to the top element on the stack
 ///
-/// The `MutCursor` stores `N` `&mut T` references, but only allows access to the [top](Self::top)
+/// The `MutCursor` stores `N` `&mut T` references, but only allows access to the [`top`](Self::top)
 pub struct MutCursor<'root, T: ?Sized + 'root, const N: usize> {
     cnt: usize, //The last item cannot be removed, so cnt==0 means there is 1 item
     top: usize,
@@ -147,7 +195,7 @@ impl<'root, T: ?Sized + 'root, const N: usize> MutCursor<'root, T, N> {
             None => false
         }
     }
-    /// Pops a reference from the stack, exposing the prior reference as the new [top](Self::top)
+    /// Pops a reference from the stack, exposing the prior reference as the new [`top`](Self::top)
     ///
     /// This method will panic if the stack contains only 1 entry
     #[inline]
@@ -197,7 +245,6 @@ impl<'root, T: ?Sized, const N: usize> core::ops::DerefMut for MutCursor<'root, 
 
 #[cfg(test)]
 mod test {
-    extern crate std;
     use std::*;
     use std::{boxed::*, vec::Vec, string::String};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,22 @@
 #![doc = include_str!("../README.md")]
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use core::ptr::NonNull;
 use core::mem::MaybeUninit;
 use core::marker::PhantomData;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 mod mut_cursor_vec;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use mut_cursor_vec::*;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 mod rooted_vec;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use rooted_vec::*;
 
 /// Stores a stack of `&mut` references, only allowing access to the top element on the stack

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,16 @@ use core::ptr::NonNull;
 use core::mem::MaybeUninit;
 use core::marker::PhantomData;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod mut_cursor_vec;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use mut_cursor_vec::*;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod rooted_vec;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use rooted_vec::*;
 
 /// Stores a stack of `&mut` references, only allowing access to the top element on the stack

--- a/src/mut_cursor_vec.rs
+++ b/src/mut_cursor_vec.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 
 /// Similar to [MutCursor](crate::MutCursor), but allows for a dynamically growing stack
 ///
-/// `MutCursorVec` is not available if the `no_std` feature is set
+/// `MutCursorVec` is not available if the `alloc` feature is disabled. (The feature is enabled by default.)
 pub struct MutCursorVec<'root, T: ?Sized + 'root> {
     top: NonNull<T>,
     stack: alloc::vec::Vec<NonNull<T>>,

--- a/src/mut_cursor_vec.rs
+++ b/src/mut_cursor_vec.rs
@@ -1,11 +1,11 @@
 
 use core::ptr::NonNull;
 use core::marker::PhantomData;
-extern crate alloc;
 
-/// Similar to [MutCursor](crate::MutCursor), but allows for a dynamically growing stack
+/// Similar to [`MutCursor`](crate::MutCursor), but allows for a dynamically growing stack
 ///
-/// `MutCursorVec` is not available if the `alloc` feature is disabled. (The feature is enabled by default.)
+/// `MutCursorVec` is not available if the [`alloc`](crate::features#alloc) feature is disabled.
+/// (The feature is enabled by default.)
 pub struct MutCursorVec<'root, T: ?Sized + 'root> {
     top: NonNull<T>,
     stack: alloc::vec::Vec<NonNull<T>>,
@@ -65,7 +65,7 @@ impl<'root, T: ?Sized + 'root> MutCursorVec<'root, T> {
         }
     }
     /// Returns the number of excess references stored in the stack, which corresponds to the number of
-    /// times [backtrack](Self::backtrack) may be called
+    /// times [`backtrack`](Self::backtrack) may be called
     #[inline]
     pub fn depth(&self) -> usize {
         self.stack.len()
@@ -92,7 +92,7 @@ impl<'root, T: ?Sized + 'root> MutCursorVec<'root, T> {
             None => false
         }
     }
-    /// Pops a reference from the stack, exposing the prior reference as the new [top](Self::top)
+    /// Pops a reference from the stack, exposing the prior reference as the new [`top`](Self::top)
     ///
     /// This method will panic if the stack contains only 1 entry
     #[inline]
@@ -104,7 +104,7 @@ impl<'root, T: ?Sized + 'root> MutCursorVec<'root, T> {
             None => panic!("MutCursor must contain valid reference")
         }
     }
-    /// Pops all references from the stack, exposing the root reference as the [top](Self::top)
+    /// Pops all references from the stack, exposing the root reference as the [`top`](Self::top)
     ///
     /// This method does nothing if the stack is already at the root
     #[inline]
@@ -143,7 +143,6 @@ impl<'root, T: ?Sized> core::ops::DerefMut for MutCursorVec<'root, T> {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
     use std::*;
     use std::boxed::*;
 

--- a/src/rooted_vec.rs
+++ b/src/rooted_vec.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 /// `MutCursorRootedVec` doesn't implement [Deref](core::ops::Deref), and accessors return [Option], so therefore it is
 /// allowed to be empty, unlike some of the other types in this crate.
 ///
-/// `MutCursorRootedVec` is not available if the `no_std` feature is set
+/// `MutCursorRootedVec` is not available if the `alloc` feature is disabled. (The feature is enabled by default.)
 pub struct MutCursorRootedVec<RootT, NodeT: ?Sized> {
     top: Option<NonNull<NodeT>>,
     root: Option<RootT>,

--- a/src/rooted_vec.rs
+++ b/src/rooted_vec.rs
@@ -2,9 +2,8 @@
 use core::{marker::PhantomData, ops::DerefMut, ptr::NonNull};
 use maybe_dangling::MaybeDangling;
 use stable_deref_trait::StableDeref;
-extern crate alloc;
 
-/// Similar to [MutCursorVec](crate::MutCursorVec), but provides for a `RootT` type at the bottom of the
+/// Similar to [`MutCursorVec`](crate::MutCursorVec), but provides for a `RootT` type at the bottom of the
 /// stack that is different from the `NodeT` types above it
 ///
 /// Usage Note: This type owns (as opposed to borrows) the root object from which the rest of the
@@ -17,13 +16,14 @@ extern crate alloc;
 /// at run-time.
 ///
 /// To give another example: If `RootT` is a container type `SomeRoot<'a>` containing `&'a mut NoteT`
-/// that you want to [advance][MutCursorRootedVec::advance_if_empty] into,
+/// that you want to [`advance`][MutCursorRootedVec::advance_if_empty] into,
 /// you could use `MutCursorRootedVec<'a, SomeRoot<'a>, NodeT>`.
 ///
-/// `MutCursorRootedVec` doesn't implement [Deref](core::ops::Deref), and accessors return [Option], so therefore it is
+/// `MutCursorRootedVec` doesn't implement [`Deref`](core::ops::Deref), and accessors return [`Option`], so therefore it is
 /// allowed to be empty, unlike some of the other types in this crate.
 ///
-/// `MutCursorRootedVec` is not available if the `alloc` feature is disabled. (The feature is enabled by default.)
+/// `MutCursorRootedVec` is not available if the [`alloc`](crate::features#alloc) feature is disabled.
+/// (The feature is enabled by default.)
 pub struct MutCursorRootedVec<'l, RootT: 'l, NodeT: ?Sized + 'l> {
     top: Option<NonNull<NodeT>>,
     root: MaybeDangling<Option<RootT>>,
@@ -303,7 +303,7 @@ impl<'l, RootT: 'l, NodeT: ?Sized + 'l> MutCursorRootedVec<'l, RootT, NodeT> {
             None => false
         }
     }
-    /// Pops a reference from the stack, exposing the prior reference as the new [top](Self::top)
+    /// Pops a reference from the stack, exposing the prior reference as the new [`top`](Self::top)
     ///
     /// If the last node entry has been removed, only the root will remain. This method will panic if
     /// it is called when the stack contains only the root
@@ -322,11 +322,11 @@ impl<'l, RootT: 'l, NodeT: ?Sized + 'l> MutCursorRootedVec<'l, RootT, NodeT> {
             }
         }
     }
-    /// Pops a reference from the stack, exposing prior reference as the new [top](Self::top),
-    /// but, unlike [backtrack](Self::backtrack) this method will not pop the bottom NodeT reference,
+    /// Pops a reference from the stack, exposing prior reference as the new [`top`](Self::top),
+    /// but, unlike [`backtrack`](Self::backtrack) this method will not pop the bottom NodeT reference,
     /// and will never panic!()
     ///
-    /// This method will do nothing if it is called when [depth](Self::depth) is `<= 1`
+    /// This method will do nothing if it is called when [`depth`](Self::depth) is `<= 1`
     #[inline]
     pub fn try_backtrack_node(&mut self) {
         match self.stack.pop() {
@@ -336,7 +336,7 @@ impl<'l, RootT: 'l, NodeT: ?Sized + 'l> MutCursorRootedVec<'l, RootT, NodeT> {
             None => {}
         }
     }
-    /// Pops all references from the stack, exposing the root reference via [root](Self::root)
+    /// Pops all references from the stack, exposing the root reference via [`root`](Self::root)
     ///
     /// This method does nothing if the stack is already at the root.
     #[inline]
@@ -345,7 +345,7 @@ impl<'l, RootT: 'l, NodeT: ?Sized + 'l> MutCursorRootedVec<'l, RootT, NodeT> {
         self.stack.clear();
     }
     /// Pops all references beyond the first from the stack, exposing the first reference
-    /// created by [advance_from_root](Self::advance_from_root) as the [top](Self::top)
+    /// created by [`advance_from_root`](Self::advance_from_root) as the [`top`](Self::top)
     ///
     /// This method does nothing if the stack is already at the root or the first node reference.
     #[inline]
@@ -363,7 +363,6 @@ impl<'l, RootT: 'l, NodeT: ?Sized + 'l> MutCursorRootedVec<'l, RootT, NodeT> {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
     use std::*;
     use std::boxed::*;
     use std::vec::Vec;

--- a/src/rooted_vec.rs
+++ b/src/rooted_vec.rs
@@ -1,41 +1,48 @@
 
-use core::ptr::NonNull;
+use core::{marker::PhantomData, ops::DerefMut, ptr::NonNull};
+use maybe_dangling::MaybeDangling;
+use stable_deref_trait::StableDeref;
 extern crate alloc;
 
 /// Similar to [MutCursorVec](crate::MutCursorVec), but provides for a `RootT` type at the bottom of the
 /// stack that is different from the `NodeT` types above it
 ///
-/// **WARNING** If `RootT` is not a smart-pointer (e.g. when it owns the memory it references)
-/// `MutCursorRootedVec` will definitely do UB! See <https://github.com/luketpeterson/mutcursor/issues/2>
-///
 /// Usage Note: This type owns (as opposed to borrows) the root object from which the rest of the
-/// stack descends, therefore, it has no associated lifetime.  Often the RootT type is a pointer
-/// itself, in which case it is the responsibility of the crate's user to maintain proper variance.
+/// stack descends, therefore, it can be used without an associated lifetime. For API soundness,
+/// you still have to define a “lower bound” for type validity.
+///
+/// In many cases, you can however simply use
+/// `MutCursorRootedVec<'static, RootT, NodeT>`. This requires `RootT: 'static` and `NodeT: 'static`
+/// which are validity bound on the *types* but these don't imply that any data must *actually* life that long
+/// at run-time.
+///
+/// To give another example: If `RootT` is a container type `SomeRoot<'a>` containing `&'a mut NoteT`
+/// that you want to [advance][MutCursorRootedVec::advance_if_empty] into,
+/// you could use `MutCursorRootedVec<'a, SomeRoot<'a>, NodeT>`.
 ///
 /// `MutCursorRootedVec` doesn't implement [Deref](core::ops::Deref), and accessors return [Option], so therefore it is
 /// allowed to be empty, unlike some of the other types in this crate.
 ///
 /// `MutCursorRootedVec` is not available if the `alloc` feature is disabled. (The feature is enabled by default.)
-pub struct MutCursorRootedVec<RootT, NodeT: ?Sized> {
+pub struct MutCursorRootedVec<'l, RootT: 'l, NodeT: ?Sized + 'l> {
     top: Option<NonNull<NodeT>>,
-    root: Option<RootT>,
+    root: MaybeDangling<Option<RootT>>,
     stack: alloc::vec::Vec<NonNull<NodeT>>,
+    _marker: PhantomData<(&'l RootT, &'l mut NodeT)>, // root covariant, node invariant
 }
+// TODO
+// unsafe impl<RootT, NodeT> Sync for MutCursorRootedVec<RootT, NodeT> where RootT: Sync, NodeT: Sync, NodeT: ?Sized {}
+// unsafe impl<RootT, NodeT> Send for MutCursorRootedVec<RootT, NodeT> where RootT: Send, NodeT: Send, NodeT: ?Sized {}
 
-unsafe impl<RootT, NodeT> Sync for MutCursorRootedVec<RootT, NodeT> where RootT: Sync, NodeT: Sync, NodeT: ?Sized {}
-unsafe impl<RootT, NodeT> Send for MutCursorRootedVec<RootT, NodeT> where RootT: Send, NodeT: Send, NodeT: ?Sized {}
-
-impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
+impl<'l, RootT: 'l, NodeT: ?Sized + 'l> MutCursorRootedVec<'l, RootT, NodeT> {
     /// Returns a new `MutCursorRootedVec` with a reference to the specified root
-    ///
-    /// **Warning** This type has serious safety limits, so constructing it is unsafe.  `RootT` must
-    /// be a smart-pointer type, e.g. [Arc](alloc::sync::Arc).
     #[inline]
-    pub unsafe fn new(root: RootT) -> Self {
+    pub fn new(root: RootT) -> Self {
         Self {
             top: None,
-            root: Some(root),
+            root: MaybeDangling::new(Some(root)),
             stack: alloc::vec::Vec::new(),
+            _marker: PhantomData,
         }
     }
     /// Returns a new `MutCursorRootedVec` with a reference to the specified root, and an allocated
@@ -44,8 +51,9 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
     pub fn new_with_capacity(root: RootT, capacity: usize) -> Self {
         Self {
             top: None,
-            root: Some(root),
+            root: MaybeDangling::new(Some(root)),
             stack: alloc::vec::Vec::with_capacity(capacity),
+            _marker: PhantomData,
         }
     }
     /// Returns `true` if the stack contains only the root, otherwise returns `false` if the stack
@@ -86,11 +94,8 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
     /// This method effectively dumps the entire stack contents.
     #[inline]
     pub fn take_root(&mut self) -> Option<RootT> {
-        let mut root = None;
-        core::mem::swap(&mut self.root, &mut root);
-        self.top = None;
-        self.stack.clear();
-        Some(root.unwrap())
+        self.to_root();
+        self.root.take()
     }
     /// Replaces the root of the stack with the provided value
     ///
@@ -98,7 +103,7 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
     #[inline]
     pub fn replace_root(&mut self, root: RootT) {
         if self.top.is_none() {
-            self.root = Some(root);
+            *self.root = Some(root);
         } else {
             panic!("Illegal operation, unable to replace borrowed root");
         }
@@ -109,18 +114,51 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
         self.top.map(|mut node_ptr| unsafe{ node_ptr.as_mut() })
     }
     /// Returns the mutable reference on the top of the stack.  If the stack contains only the root, this
-    /// method will behave as if [advance_if_empty](Self::advance_if_empty) was called prior to [top_mut](Self::top_mut)
+    /// method will behave as if [`advance_if_empty`](Self::advance_if_empty) was called prior
+    /// to [`top_mut`](Self::top_mut).
     ///
-    /// Panics if the root has been taken via [Self::take_root]
+    /// Panics if the root has been taken via [`Self::take_root`]
     #[inline]
-    pub fn top_or_advance_mut<F>(&mut self, step_f: F) -> &mut NodeT
-        where F: FnOnce(&mut RootT) -> &mut NodeT
+    pub fn top_or_advance_mut<F, NodeRef>(&mut self, step_f: F) -> &mut NodeT
+    where
+        F: FnOnce(&mut RootT) -> &mut NodeRef,
+        NodeRef: DerefMut<Target = NodeT> + StableDeref + 'l,
+        // Due to the effects of implied bounds, this   ^^^^  is important for soundness
     {
         match &self.top {
             Some(mut node_ptr) => unsafe{ node_ptr.as_mut() },
             None => {
-                let new_node = step_f(self.root.as_mut().unwrap());
                 debug_assert_eq!(self.stack.len(), 0);
+                let new_node_stable_ref = step_f(self.root.as_mut().unwrap());
+                let mut node_ptr = NonNull::from(&mut **new_node_stable_ref);
+                self.top = Some(node_ptr);
+                unsafe{ node_ptr.as_mut() }
+            }
+        }
+    }
+    /// Returns the mutable reference on the top of the stack.  If the stack contains only the root, this
+    /// method will behave as if [`advance_if_empty_twostep`](Self::advance_if_empty_twostep) was called prior
+    /// to [`top_mut`](Self::top_mut).
+    ///
+    /// Panics if the root has been taken via [`Self::take_root`]
+    ///
+    /// This version of [`top_or_advance_mut`][Self::top_or_advance_mut] supports
+    /// a second step, when the `RootT` doesn't contain any stable pointers
+    /// *directly* to a `NodeT`.
+    #[inline]
+    pub fn top_or_advance_mut_twostep<F, G, IntermediateRef>(&mut self, step_f1: F, step_f2: G) -> &mut NodeT
+    where
+        F: FnOnce(&mut RootT) -> &mut IntermediateRef,
+        IntermediateRef: DerefMut + StableDeref + 'l,
+        // Due to the effects of implied bounds ^^^^ this is important for soundness
+        G: FnOnce(&mut IntermediateRef::Target) -> &mut NodeT,
+    {
+        match &self.top {
+            Some(mut node_ptr) => unsafe{ node_ptr.as_mut() },
+            None => {
+                debug_assert_eq!(self.stack.len(), 0);
+                let intermediate_stable_ref = step_f1(self.root.as_mut().unwrap());
+                let new_node = step_f2(intermediate_stable_ref);
                 let mut node_ptr = NonNull::from(new_node);
                 self.top = Some(node_ptr);
                 unsafe{ node_ptr.as_mut() }
@@ -129,10 +167,10 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
     }
     /// Returns the mutable reference on the root of the stack, consuming the stack
     ///
-    /// Panics if the root of the stack has already been taken via [Self::take_root]
+    /// Panics if the root of the stack has already been taken via [`Self::take_root`]
     #[inline]
     pub fn into_root(self) -> RootT {
-        self.root.unwrap()
+        MaybeDangling::into_inner(self.root).unwrap()
     }
     /// Returns the number of node references stored in the stack, which corresponds to the number of
     /// times [backtrack](Self::backtrack) may be called before the stack is empty
@@ -154,37 +192,83 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
     }
     /// Begins the traversal if the stack contains only the root, otherwise does nothing
     ///
-    /// Panics if the root has been taken via [Self::take_root]
+    /// Panics if the root has been taken via [`Self::take_root`]
     #[inline]
-    pub fn advance_if_empty<F>(&mut self, step_f: F)
-        where F: FnOnce(&mut RootT) -> &mut NodeT
+    pub fn advance_if_empty<F, NodeRef>(&mut self, step_f: F)
+    where
+        F: FnOnce(&mut RootT) -> &mut NodeRef,
+        NodeRef: DerefMut<Target = NodeT> + StableDeref + 'l,
+        // Due to the effects of implied bounds, this   ^^^^  is important for soundness
+    {
+        self.advance_if_empty_twostep(step_f, |node| node);
+    }
+    /// Begins the traversal if the stack contains only the root, otherwise does nothing
+    ///
+    /// Panics if the root has been taken via [`Self::take_root`]
+    ///
+    /// This version of [`advance_if_empty`][Self::advance_if_empty] supports
+    /// a second step, when the `RootT` doesn't contain any stable pointers
+    /// *directly* to a `NodeT`.
+    #[inline]
+    pub fn advance_if_empty_twostep<F, G, IntermediateRef>(&mut self, step_f1: F, step_f2: G)
+    where
+        F: FnOnce(&mut RootT) -> &mut IntermediateRef,
+        IntermediateRef: DerefMut + StableDeref + 'l,
+        // Due to the effects of implied bounds ^^^^ this is important for soundness
+        G: FnOnce(&mut IntermediateRef::Target) -> &mut NodeT,
     {
         if self.top.is_none() {
-            let new_node = step_f(self.root.as_mut().unwrap());
             debug_assert_eq!(self.stack.len(), 0);
+            let intermediate_stable_ref = step_f1(self.root.as_mut().unwrap());
+            let new_node = step_f2(intermediate_stable_ref);
             let node_ptr = NonNull::from(new_node);
             self.top = Some(node_ptr);
         }
     }
     /// Begins the traversal by stepping from the root to the first node, pushing the first node
-    /// reference onto the stack.  Effectively resets the stack
+    /// reference onto the stack. Always resets the stack.
     ///
-    /// If the `step_f` closure returns `Some` the existing stack will be replaced.
-    /// If the `step_f` closure returns `None`, the stack will not be modified.
+    /// If the `step_f` closure returns `Some` the existing stack will be replaced with the new node.
+    /// If the `step_f` closure returns `None` the stack will be left completely empty.
     ///
-    /// Panics if the root has been taken via [Self::take_root]
+    /// Panics if the root has been taken via [`Self::take_root`]
     #[inline]
-    pub fn advance_from_root<F>(&mut self, step_f: F) -> bool
-        where F: FnOnce(&mut RootT) -> Option<&mut NodeT>
+    pub fn advance_from_root<F, NodeRef>(&mut self, step_f: F) -> bool
+    where
+        F: FnOnce(&mut RootT) -> Option<&mut NodeRef>,
+        NodeRef: DerefMut<Target = NodeT> + StableDeref + 'l,
+        // Due to the effects of implied bounds, this   ^^^^  is important for soundness
     {
-        match step_f(self.root.as_mut().unwrap()) {
-            Some(new_node) => {
-                self.stack.clear();
-                self.top = Some(NonNull::from(new_node));
-                true
-            },
-            None => false
+        self.advance_from_root_twostep(step_f, |node| Some(node))
+    }
+    /// Begins the traversal by stepping from the root to the first node, pushing the first node
+    /// reference onto the stack. Always resets the stack.
+    ///
+    /// If either of the `step_f…` closures returns `Some` the existing stack will be replaced with the new node.
+    /// If either of the `step_f…` closures returns `None` the stack will be left completely empty.
+    ///
+    /// Panics if the root has been taken via [`Self::take_root`]
+    ///
+    /// This version of [`advance_from_root`][Self::advance_from_root] supports
+    /// a second step, when the `RootT` doesn't contain any stable pointers
+    /// *directly* to a `NodeT`.
+    #[inline]
+    pub fn advance_from_root_twostep<F, G, IntermediateRef>(&mut self, step_f1: F, step_f2: G) -> bool
+    where
+        F: FnOnce(&mut RootT) -> Option<&mut IntermediateRef>,
+        IntermediateRef: DerefMut + StableDeref + 'l,
+        // Due to the effects of implied bounds ^^^^ this is important for soundness
+        G: FnOnce(&mut IntermediateRef::Target) -> Option<&mut NodeT>,
+    {
+        self.to_root();
+        if let Some(intermediate_stable_ref) = step_f1(self.root.as_mut().unwrap()) {
+            if let Some(new_node) = step_f2(intermediate_stable_ref) {
+                let node_ptr = NonNull::from(new_node);
+                self.top = Some(node_ptr);
+                return true;
+            }
         }
+        false
     }
     /// Steps deeper into the traversal, pushing a new reference onto the top of the stack
     ///
@@ -200,10 +284,9 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
     {
         match step_f(self.top_mut().expect("Cursor at root. Must call `advance_from_root` before `advance`")) {
             Some(new_node) => {
-                let mut old_top = Some(NonNull::from(new_node));
-                core::mem::swap(&mut old_top, &mut self.top);
-                if let Some(old_top) = old_top {
-                    self.stack.push(NonNull::from(old_top));
+                let new_ptr = NonNull::from(new_node);
+                if let Some(old_top) = self.top.replace(new_ptr) {
+                    self.stack.push(old_top);
                 }
                 true
             },
@@ -248,8 +331,8 @@ impl<RootT, NodeT: ?Sized> MutCursorRootedVec<RootT, NodeT> {
     /// This method does nothing if the stack is already at the root.
     #[inline]
     pub fn to_root(&mut self) {
-        self.stack.clear();
         self.top = None;
+        self.stack.clear();
     }
     /// Pops all references beyond the first from the stack, exposing the first reference
     /// created by [advance_from_root](Self::advance_from_root) as the [top](Self::top)


### PR DESCRIPTION
fixes #2; and then I’ve also spend some ~~(too much)~~ time on making links in the documentation better.

this builds on top of the branch from #3 (first 4 commits), so if you want to merge both (separately), doing #3 first is reasonable

---

So I've had the idea of this API-design, with the most-general two-step projection, when considering how to support the setting of the existing `test` case. In theory there could be up to 4 different versions of each of the API: the most general two-step one, the one that's default in this PR where the second step of the two-step approach is skipped and you project down to some reference to a node (`Box` in the test case);  
and then it’d be possible to instead leave out  the first step instead, requiring `Root: DerefMut + StableDeref` and starting a `step_f` only from the target of that reference, or *in principle* even a version without any additional arguments that just handles the case where `Root` itself *directly* is a stable pointer to a node, e.g. `MutCursorRootedVec::<Box<TreeNode>, TreeNode>`. I've left out these additional versions though.

feel free to take a look at this API, what do you think? Instead of trying to explain everything up-front, perhaps you simply ask questions ;-)